### PR TITLE
Testsuite, hello world, return to service and fixes

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,3 +1,4 @@
 [defaults]
 log_path=execution.log
-
+#TODO: Reenable host key checking after provisioning compute nodes/exchange keys.
+host_key_checking=False

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -83,7 +83,7 @@ enable_mpi_opa: false
 enable_clustershell: true
 enable_ipmisol: false
 enable_opensm: false
-enable_mellanox_ib: true
+enable_mellanox_ib: false
 enable_linux_ib: false
 enable_ipoib: false
 enable_ganglia: true

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -123,6 +123,8 @@ compute_nodes:
 - { num: 1, c_name: "c1", c_ip: "192.168.44.21", c_mac: "52:54:00:44:00:01", c_bmc: "192.168.66.11"}
 - { num: 2, c_name: "c2", c_ip: "192.168.44.22", c_mac: "52:54:00:44:00:02", c_bmc: "192.168.66.12"}
 
+# This flag forces ReturnToService=2 on all nodes in slurm.
+force_service: False
 
 # Optional settings
 #

--- a/roles/helloworld/defaults/main.yml
+++ b/roles/helloworld/defaults/main.yml
@@ -1,0 +1,1 @@
+enable_helloworld: False

--- a/roles/helloworld/tasks/main.yml
+++ b/roles/helloworld/tasks/main.yml
@@ -1,0 +1,40 @@
+- block:
+  - name: Add user test to master
+    user:
+      name: test
+      comment: Test User for Hello World MPI test
+      state: present
+    when:
+      - inventory_hostname in groups[nt_sms]
+
+  - name: Propagate this to the computes in stateful
+    user:
+      name: test
+      comment: Test User for Hello World MPI test
+      state: present
+    when:
+      - inventory_hostname in groups[nt_cnodes]
+      - enable_warewulf == false
+
+  - name: Propagate this to the computes in stateless
+    shell: wwsh file resync passwd shadow group
+    when:
+      - inventory_hostname in groups[nt_sms]
+      - enable_warewulf == True
+
+  - name: Run the Hello World test
+    become: yes
+    become_method: su
+    become_user: test
+    shell: "cd /home/test/ && mpicc -O3 /opt/ohpc/pub/examples/mpi/hello.c && srun -n 8 -N {{ num_computes }} --mpi=pmix /home/test/a.out"
+    register: test_output
+    when:
+      - inventory_hostname in groups[nt_sms]
+      - enable_nfs_home == True
+
+  - debug: msg="{{ test_output.stdout_lines }}"
+    when:
+      - inventory_hostname in groups[nt_sms]
+
+  when:
+    - enable_helloworld == True

--- a/roles/nfs/tasks/main.yml
+++ b/roles/nfs/tasks/main.yml
@@ -30,6 +30,7 @@
     state: present
   when:
     - inventory_hostname in groups[nt_cnodes]
+    - enable_nfs_home == true
 
 #echo "${sms_ip}:/opt/ohpc/pub /opt/ohpc/pub nfs nfsvers=3 0 0" >> $CHROOT/etc/fstab
 - name: Add NFS client to mount /opt/ohpc/pub on a computing node
@@ -41,17 +42,6 @@
   when:
     - inventory_hostname in groups[nt_cnodes]
     - enable_nfs_ohpc == true
-
-- name: NFS client to mount /home on a computing node
-  mount:
-    name: "/home"
-    src: "{{ sms_ip }}{{ d_colon }}/home"
-    fstype: nfs
-    opts: "rsize=1024,wsize=1024,cto"
-    state: mounted
-  when:
-    - inventory_hostname in groups[nt_cnodes]
-    - enable_nfs_home == true
 
 #echo "/home *(rw,no_subtree_check,fsid=10,no_root_squash)" >> /etc/exports
 - name: Export /home on master

--- a/roles/slurm-client/defaults/main.yml
+++ b/roles/slurm-client/defaults/main.yml
@@ -6,3 +6,5 @@
 
 slurm_mpi_default: 'none'
 slurm_max_time: 'INFINITE'
+# This flag makes ReturnToService=2 instead of =1
+force_service: False

--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -80,6 +80,11 @@
   - name: Set MpiDefault default is none/up to the implementation (fails on aarch64)
     replace: dest=/etc/slurm/slurm.conf regexp='^MpiDefault=(\S+)' replace="MpiDefault={{ slurm_mpi_default }}" backup=yes
 
+  - name: replace ReturnToService
+    replace: dest="/etc/slurm/slurm.conf" regexp='ReturnToService=1' replace="ReturnToService=2" backup=yes
+    when: 
+      - force_service == True
+
   when: 
     ( ( inventory_hostname in groups[nt_sms] ) or
     ( inventory_hostname in groups[nt_devnodes] ) or
@@ -103,6 +108,11 @@
 
   - name: Set MpiDefault default is none/up to the implementation (fails on aarch64)
     replace: dest="{{ compute_chroot_loc }}/etc/slurm/slurm.conf" regexp='^MpiDefault=(\S+)' replace="MpiDefault={{ slurm_mpi_default }}" backup=yes
+
+  - name: replace ReturnToService
+    replace: dest="{{ compute_chroot_loc }}/etc/slurm/slurm.conf" regexp='ReturnToService=1' replace="ReturnToService=2" backup=yes
+    when: 
+      - force_service == True
 
   when: 
     - inventory_hostname in groups[nt_sms]

--- a/roles/test-suite-ohpc/defaults/main.yml
+++ b/roles/test-suite-ohpc/defaults/main.yml
@@ -1,0 +1,110 @@
+enable_junit: False
+
+configure_packages:
+  - name: long
+    status: disable
+  - name: adios
+    status: disable
+  - name: boost
+    status: disable
+  - name: boost-mpi
+    status: disable
+  - name: compilers
+    status: disable
+  - name: fftw
+    status: disable
+  - name: gsl
+    status: disable
+  - name: hdf5
+    status: disable
+  - name: hwloc
+    status: disable
+  - name: hypre
+    status: disable
+  - name: imb
+    status: disable
+  - name: mpi
+    status: disable
+  - name: mumps
+    status: disable
+  - name: mfem
+    status: disable
+  - name: minife
+    status: disable
+  - name: netcdf
+    status: disable
+  - name: numpy
+    status: disable
+  - name: ocr
+    status: disable
+  - name: petsc
+    status: disable
+  - name: phdf5
+    status: disable
+  - name: plasma
+    status: disable
+  - name: pnetcdf
+    status: disable
+  - name: ptscotch
+    status: disable
+  - name: R
+    status: disable
+  - name: scotch
+    status: disable
+  - name: slepc
+    status: disable
+  - name: superlu
+    status: disable
+  - name: superlu_dist
+    status: disable
+  - name: scalasca
+    status: disable
+  - name: scipy
+    status: disable
+  - name: tau
+    status: disable
+  - name: trilinos
+    status: disable
+  - name: valgrind
+    status: disable
+  - name: hpcg
+    status: disable
+  - name: prk
+    status: disable
+  - name: autotools
+    status: disable
+  - name: cmake
+    status: disable
+  - name: charliecloud
+    status: disable
+  - name: easybuild
+    status: disable
+  - name: metis
+    status: disable
+  - name: tbb
+    status: disable
+  - name: minidft
+    status: disable
+  - name: cilk
+    status: disable
+  - name: munge
+    status: disable
+  - name: mpi4py
+    status: disable
+  - name: mpiP
+    status: disable
+  - name: openblas
+    status: disable
+  - name: rms-harness
+    status: disable
+  - name: scalapack
+    status: disable
+  - name: papi
+    status: disable
+  - name: likwid
+    status: disable
+  - name: packaging
+    status: disable
+
+mpi_families: openmpi3
+compiler_families: gnu7

--- a/roles/test-suite-ohpc/tasks/main.yml
+++ b/roles/test-suite-ohpc/tasks/main.yml
@@ -1,0 +1,94 @@
+- name: Create the ohpc-test user on cnodes
+  user:
+    name: ohpc-test
+  when:
+    - enable_warewulf == False
+    - inventory_hostname in groups[nt_cnodes]
+
+- name: Create the ohpc-test user on cnodes with warewulf
+  shell: "wwsh file resync passwd shadow group ; pdsh -w {{ compute_regex }} /warewulf/bin/wwgetfiles"
+  when:
+    - inventory_hostname in groups[nt_sms]
+    - enable_warewulf == True
+
+- block:
+    - name: Uninstall test-suite
+      yum:
+        name: test-suite-ohpc
+        state: absent
+
+    - name: Wipe out anything test-suite related
+      shell: rm -rf /home/ohpc-test/tests
+
+  when:
+    - inventory_hostname in groups[nt_sms]
+
+- block:
+    - name: Install test suite
+      yum:
+        name: test-suite-ohpc
+        state: latest
+
+    - name: Install TAU for openmpi3 (default is mpich)
+      yum:
+        name: tau-gnu7-openmpi3-ohpc
+        state: latest
+
+    - name: Create the ohpc-test user on cnodes
+      shell: "wwsh file resync passwd shadow group ; pdsh -w {{ compute_regex }} /warewulf/bin/wwgetfiles"
+      when:
+        - enable_warewulf == True
+
+    - name: Render configure script template
+      template:
+        src: "{{ role_path }}/templates/configure.sh.j2"
+        dest: /home/ohpc-test/configure.sh
+        group: ohpc-test
+        owner: ohpc-test
+        mode: 0744
+
+    - name: Configure test suite
+      shell: /home/ohpc-test/configure.sh
+      become: yes
+      become_user: ohpc-test
+      become_method: su
+      register: testsuite_configure
+
+    - debug: msg="{{ testsuite_configure.stdout_lines }} {{ testsuite_configure.stderr_lines }}"
+
+    - name: Run the test suite with JUnit xml output in addition to regular logs
+      shell: cd /home/ohpc-test/tests && make check
+      environment:
+        BATS_JUNIT_FORMAT: "1"
+      become: yes
+      become_user: ohpc-test
+      become_method: su
+      register: testsuite_output
+
+    - debug: msg="{{ testsuite_output.stdout_lines }} {{ testsuite_output.stderr_lines }}"
+
+    - block:
+        - name: If we want, get those xml JUnit logs back
+          find:
+            paths: /home/ohpc-test/tests
+            recurse: yes
+            patterns: "*.xml"
+          register: xml_junit_files
+
+        - name: Archive all those files
+          archive:
+            path: "{{ xml_junit_files.files | map(attribute='path') | list }}"
+            dest: "/tmp/junit-results.tar.gz"
+            format: gz
+
+        - name: Fetch the archive
+          fetch:
+            src: "/tmp/junit-results.tar.gz"
+            dest: "{{ playbook_dir }}/../"
+
+      when:
+        - enable_junit == True
+
+  when:
+    - inventory_hostname in groups[nt_sms]
+    - enable_testsuiteohpc == True

--- a/roles/test-suite-ohpc/templates/configure.sh.j2
+++ b/roles/test-suite-ohpc/templates/configure.sh.j2
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd /home/ohpc-test/tests
+./configure {% for pkg in configure_packages %} --{{ pkg.status }}-{{ pkg.name }} {% endfor %} --with-mpi-families={{ mpi_families }} --with-compiler-families={{ compiler_families }}

--- a/run_testsuite.yml
+++ b/run_testsuite.yml
@@ -1,0 +1,5 @@
+- hosts: all
+  user: root
+  become: yes
+  roles:
+    - test-suite-ohpc

--- a/site.yml
+++ b/site.yml
@@ -89,3 +89,4 @@
     - warewulf-final
     # - booting-computing-nodes
     - final 
+    - helloworld


### PR DESCRIPTION
This merge will add the following features to the playbook, all disabled by default :
- Added Hello World MPI test (section 6.1 of 1.3.6 pdf)
- Added role to run the upstream OpenHPC test suite
- Added a flag "force_service" to put ReturnToService=2 in slurm.conf for the cluster

ReturnToService=2 is to account for the fact that our clusters, when being tested might get reprovisioned/rebooted and in general might go down from Slurm's point of view. This flag force Slurm to put the nodes UP as soon as possible after they went down (whereas without it, the machines might get stuck in a Drain state).

The other patches are fixes to issues :
- Disable host key checking by default, this has an associated todo : reenable host key checking after having gotten the host key of the compute nodes (that might get reprovisioned)
- NFS issue, where a directory was mounted before being exported
- Disable Mellanox OFED installation by default