### PR TITLE
Force a munge daemon restart in final

### DIFF
--- a/roles/final/tasks/main.yml
+++ b/roles/final/tasks/main.yml
@@ -60,3 +60,9 @@
   when:
     - inventory_hostname in groups[ nt_cnodes ]
 
+#Restart munge on computing nodes
+- name: Start munge on a computing node
+  service: name=munge state=restarted
+  when:
+    - inventory_hostname in groups[ nt_cnodes ]
+


### PR DESCRIPTION
I have encountered issues with munge authentication in slurm, it seems the munge daemon _sometimes_ gets stuck or badly initialized at the end of the playbook (after the final task in the "final" role).
Restarting it after slurm seems to fix this unstability.