### PR TITLE
Add socketdirect support for MOFED

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -272,6 +272,8 @@ The following are the configuration variables with their default values. You can
  - enable_nfs_home: true/false  (default: true)
    To export `/home` directory from SMS, set this variable true.
    It would be advisable to set this *false* in the Linaro Lab because it is a diskful cluster and you would not want to overshadow the `/home` directory of a member node.
+ - force_service : true/false (default: false)
+   This flag sets ReturnToService in slurm.conf to 2 (instead of the default 0), meaning that in case a node is DOWN (for whatever reason) upon registration (and if its configuration is valid) its state is reset to UP (see https://slurm.schedmd.com/slurm.conf.html)
  - internal_default_lease_time
    default DHCP lease time.
  - internal_max_lease_time

--- a/Readme.md
+++ b/Readme.md
@@ -244,6 +244,12 @@ The following are the configuration variables with their default values. You can
    Installs packages specifically for Intel's interconnect if true.
  - enable_ipoib: true/false  (default: false)
    \[Not fully tested; feedback welcome\] Sets up IP over IB if true.
+ - enable_mellanox_ib: true/false (default: false)
+   Installs Mellanox OFED provided by URL "mellanox_iso_url" and filename "mellanox_iso_file", additional installation options (when calling mlnxofedinstall) are provided by variable "mofed_install_opts"
+ - enable_linux_ib: true/false (default: false)
+   Installs Open Source Infiniband Support for the system. This is not compatible with socket direct, and will not update the IB card firmware (thus no need to reboot).
+ - enable_socket_direct: true/false (default: false)
+   Enables Socket Direct support for Mellanox IB Adapters via the "virtualization" option in OpenSM. This needs enable_opensm to be true as well, and requires MOFED since the upstream OpenSM in the repos does not have this feature.
  - enable_ganglia: true/false  (default: true)
    Installs ganglia packages if true.
  - enable_genders: true/false  (default: true)

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -83,6 +83,7 @@ enable_mpi_opa: false
 enable_clustershell: true
 enable_ipmisol: false
 enable_opensm: false
+enable_socket_direct: false
 enable_mellanox_ib: false
 enable_linux_ib: false
 enable_ipoib: false

--- a/roles/net-ib/tasks/main.yml
+++ b/roles/net-ib/tasks/main.yml
@@ -68,16 +68,29 @@
         - atk
         - gcc-gfortran
         - tk
+        - python-devel
+        - pciutils
+        - make
+        - kernel-devel
+        - redhat-rpm-config
+        - rpm-build
+        - gcc
+        - libxml2-python
+        - tcsh
+        - tcl
       when:
         - inventory_hostname in groups[nt_sms]
 
 #./mnt/mlnxofedinstall --all  --force
     - name: run a script "/mnt/mlnxofedinstall --force" on master
-      shell: /mnt/mlnx/mlnxofedinstall --force
+      shell: "/mnt/mlnx/mlnxofedinstall --force {{ mofed_install_opts }}"
       register: result
       failed_when: result.rc not in [0]
       when:
         - inventory_hostname in groups[nt_sms]
+
+    - name: Dump MOFED Install log
+      debug: var=result
  
 # sleep 2 && shutdown -r now   
     - name: restart sms machine
@@ -99,6 +112,36 @@
         - enable_reboot == true        
   when:
     - enable_mellanox_ib == true
+
+# Optionally enable opensm subnet manager
+#if [[ ${enable_opensm} -eq 1 ]];then
+- block:
+
+#     yum -y install opensm
+  - name: Install opensm on master
+    yum: name={{ item }} state=latest
+    with_items:
+      - opensm
+
+  - name: Enable virtualization in OpenSM
+    lineinfile:
+      path: /etc/opensm/opensm.conf
+      line: 'virt_enabled 2'
+      create: yes
+    when: enable_socket_direct == true
+
+#     systemctl enable opensm
+  - name: Enable opensm on master
+    service: name=opensm enabled=yes
+
+#     systemctl start opensm
+  - name: Start opensm on master
+    service: name=opensm state=started
+
+  when:
+    - enable_opensm == true
+    - inventory_hostname in groups[nt_sms]
+#fi
 
 #if [[ ${enable_ipoib} -eq 1 ]];then
 - block:
@@ -191,7 +234,7 @@
         - enable_warewulf == true
 
     - name: run a script /mnt/mlnxofedinstall --force to computing node images on master
-      shell: "{{ compute_chroot_loc }}/mnt/mlnx/mlnxofedinstall --force"
+      shell: "{{ compute_chroot_loc }}/mnt/mlnx/mlnxofedinstall --force {{ mofed_install_opts }}"
       register: result
       failed_when: result.rc not in [0]
       when:
@@ -230,7 +273,7 @@
         - enable_warewulf == false
 
     - name: run a script "/mnt/mlnxofedinstall --force" on computing node
-      shell: /mnt/mlnx/mlnxofedinstall --force
+      shell: "/mnt/mlnx/mlnxofedinstall --force {{ mofed_install_opts }}" 
       register: result
       failed_when: result.rc not in [0]
       when:
@@ -258,6 +301,7 @@
 
   when:
     - enable_mellanox_ib == true  
+
 - block:
 
   - name: Create an ifcfg-ib file on compute nodes
@@ -318,30 +362,6 @@
     - enable_ipoib == true
     - enable_ifup == true
     - enable_warewulf == false
-
-# Optionally enable opensm subnet manager
-#if [[ ${enable_opensm} -eq 1 ]];then
-- block:
-
-#     yum -y install opensm
-  - name: Install opensm on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - opensm
-
-#     systemctl enable opensm
-  - name: Enable opensm on master
-    service: name=opensm enabled=yes
-
-#     systemctl start opensm
-  - name: Start opensm on master
-    service: name=opensm state=started
-
-  when: 
-    - enable_opensm == true
-    - inventory_hostname in groups[nt_sms]
-#fi
-
 
 
 #perl -pi -e 's/# End of file/\* soft memlock unlimited\n$&/s' /etc/security/limits.conf


### PR DESCRIPTION
This patch adds support for Socket Direct (MultiHost) support for the Infiniband enablement part of the recipe.
This reorders the openSM installation, and adds a block in MOFED installation especially for SocketDirect which needs virtualization enabled in the subnet manager (only available in Mellanox' version of OpenSM).

It introduces two new variables, described in the readme:
- enable_socketdirect
- mofed_install_opts