### PR TITLE
yum uses array of names directly, instead of with_items

### DIFF
--- a/roles/clustershell/tasks/main.yml
+++ b/roles/clustershell/tasks/main.yml
@@ -25,9 +25,10 @@
 #     # Install clustershell
 #     yum -y install clustershell-ohpc
   - name: Install clustershell on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - clustershell-ohpc
+    yum:
+      state: latest
+      name:
+        - clustershell-ohpc
     when:
       - inventory_hostname in groups[nt_sms]
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -25,11 +25,12 @@
 # combination of the package installation.
 #
 - name: Install basic packages to perfrom OpenHPC installation
-  yum: name={{ item }} state=latest
-  with_items:
-    - perl
-    - dhcp
-    - firewalld
+  yum:
+    state: latest
+    name:
+      - perl
+      - dhcp
+      - firewalld
   when:
     ( inventory_hostname in groups[nt_sms] ) or
     ( inventory_hostname in groups[nt_devnodes] ) or

--- a/roles/conman/tasks/main.yml
+++ b/roles/conman/tasks/main.yml
@@ -24,9 +24,10 @@
 - block:
 #     yum -y install conman-ohpc
   - name: Install conman-ohpc on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - conman-ohpc
+    yum:
+      state: latest
+      name:
+        - conman-ohpc
     when:
       - inventory_hostname in groups[nt_sms]
 

--- a/roles/ganglia/tasks/main.yml
+++ b/roles/ganglia/tasks/main.yml
@@ -23,25 +23,29 @@
 #     # Install Ganglia on master
 #     yum -y groupinstall ohpc-ganglia
   - name: Install ohpc-ganglia on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - ohpc-ganglia
+    yum:
+      state: latest
+      name:
+        - ohpc-ganglia
     when:
       - inventory_hostname in groups[nt_sms]
 
 #     yum -y --installroot=$CHROOT install ganglia-gmond-ohpc
   - name: Install ganglia-gmond-ohpc for computing image on master
-    yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-    with_items:
-      - ganglia-gmond-ohpc
+    yum:
+      state: latest
+      installroot: "{{ compute_chroot_loc }}"
+      name:
+        - ganglia-gmond-ohpc
     when:
       - inventory_hostname in groups[nt_sms]
       - enable_warewulf == true
 
   - name: Install ganglia-gmond-ohpc on a computing node
-    yum: name={{ item }} state=latest
-    with_items:
-      - ganglia-gmond-ohpc
+    yum:
+      state: latest
+      name:
+        - ganglia-gmond-ohpc
     when:
       - inventory_hostname in groups[nt_cnodes]
       - enable_warewulf == false

--- a/roles/genders/tasks/main.yml
+++ b/roles/genders/tasks/main.yml
@@ -26,9 +26,10 @@
 #     # Install genders
 #     yum -y install genders-ohpc
   - name: Install genders-ohpc on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - genders-ohpc
+    yum:
+      state: latest
+      name:
+        - genders-ohpc
     when:
       - inventory_hostname in groups[nt_sms]
 

--- a/roles/imb/tasks/main.yml
+++ b/roles/imb/tasks/main.yml
@@ -21,18 +21,20 @@
 #
 
 - name: Install Intel MPI Bench on master
-  yum: name={{ item }} state=latest
-  with_items:
-    - imb-gnu7-openmpi-ohpc
-    - imb-gnu7-openmpi3-ohpc
-    - imb-gnu7-mpich-ohpc
+  yum:
+    state: latest
+    name:
+      - imb-gnu7-openmpi-ohpc
+      - imb-gnu7-openmpi3-ohpc
+      - imb-gnu7-mpich-ohpc
   when:
     - inventory_hostname in groups[nt_sms]
 
 - name: Install Intel MPI Bench for mvapich2 on master
-  yum: name={{ item }} state=latest
-  with_items:
-    - imb-gnu7-mvapich2-ohpc
+  yum:
+    state: latest
+    name:
+      - imb-gnu7-mvapich2-ohpc
   when:
     - inventory_hostname in groups[nt_sms]
     - ansible_machine == "x86_64"

--- a/roles/lustre-client/tasks/main.yml
+++ b/roles/lustre-client/tasks/main.yml
@@ -25,29 +25,33 @@
 #     # Install Lustre client on master
 #     yum -y install lustre-client-ohpc lustre-client-ohpc-modules
   - name: install Lustre client on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - lustre-client-ohpc
-      - lustre-client-ohpc-modules
+    yum:
+      state: latest
+      name:
+        - lustre-client-ohpc
+        - lustre-client-ohpc-modules
     when:
       - inventory_hostname in groups[nt_sms]
 
 #     # Enable lustre in a computing node
 #     yum -y --installroot=$CHROOT install lustre-client-ohpc lustre-client-ohpc-modules
   - name: Install Lustre-client for computing node images on master
-    yum: name={{ item }}  installroot="{{ compute_chroot_loc }}" state=latest
-    with_items:
-      - lustre-client-ohpc
-      - lustre-client-ohpc-modules
+    yum:
+      state: latest
+      installroot: "{{ compute_chroot_loc }}"
+      name:
+        - lustre-client-ohpc
+        - lustre-client-ohpc-modules
     when:
       - inventory_hostname in groups[nt_sms]
       - enable_warewulf == true
 
   - name: Install Lustre-client on a computing node
-    yum: name={{ item }}  state=latest
-    with_items:
-      - lustre-client-ohpc
-      - lustre-client-ohpc-modules
+    yum:
+      state: latest
+      name:
+        - lustre-client-ohpc
+        - lustre-client-ohpc-modules
     when:
       - inventory_hostname in groups[nt_cnodes]
       - enable_warewulf == false

--- a/roles/mpich-gnu/tasks/main.yml
+++ b/roles/mpich-gnu/tasks/main.yml
@@ -25,10 +25,11 @@
 #     yum -y install openmpi-psm2-gnu8-ohpc mvapich2-psm2-gnu8-ohpc
 #fi
 - name: Install default MPI Stacks on master and a development node
-  yum: name={{ item }} state=latest
-  with_items:
-    - "mpich-gnu{{ gnu_version }}-ohpc"
-    - "ohpc-gnu{{ gnu_version }}-mpich-parallel-libs"
+  yum:
+    state: latest
+    name:
+      - "mpich-gnu{{ gnu_version }}-ohpc"
+      - "ohpc-gnu{{ gnu_version }}-mpich-parallel-libs"
   when: 
     ( enable_mpi_defaults == true ) and
     ( enable_mpi_opa == false ) and
@@ -36,10 +37,12 @@
     ( ( inventory_hostname in groups[nt_cnodes] ) and ( enable_warewulf == false ) ) )
 
 - name: Install default MPI Stacks for a computing image on master
-  yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-  with_items:
-    - "mpich-gnu{{ gnu_version }}-ohpc"
-    - "ohpc-gnu{{ gnu_version }}-mpich-parallel-libs"
+  yum:
+    state: latest
+    installroot: "{{ compute_chroot_loc }}"
+    name:
+      - "mpich-gnu{{ gnu_version }}-ohpc"
+      - "ohpc-gnu{{ gnu_version }}-mpich-parallel-libs"
   when: 
     - enable_mpi_defaults == true
     - enable_mpi_opa == false

--- a/roles/mrsh/tasks/main.yml
+++ b/roles/mrsh/tasks/main.yml
@@ -25,19 +25,21 @@
 #     # Install mrsh
 #     yum -y install mrsh-ohpc mrsh-rsh-compat-ohpc
   - name: Install mrsh-ohpc mrsh-rsh-compat-ohpc on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - mrsh-ohpc
-      - mrsh-rsh-compat-ohpc
+    yum:
+      state: latest
+      name:
+        - mrsh-ohpc
+        - mrsh-rsh-compat-ohpc
     when:
       - inventory_hostname in groups[nt_sms]
 
   - name: Install mrsh-ohpc mrsh-rsh-compat-ohpc mrsh-server-ohpc on a computing node
-    yum: name={{ item }}  state=latest
-    with_items:
-      - mrsh-ohpc
-      - mrsh-rsh-compat-ohpc
-      - mrsh-server-ohpc
+    yum:
+      state: latest
+      name:
+        - mrsh-ohpc
+        - mrsh-rsh-compat-ohpc
+        - mrsh-server-ohpc
     when:
       - inventory_hostname in groups[nt_cnodes]
       - enable_warewulf == false

--- a/roles/nagios/tasks/main.yml
+++ b/roles/nagios/tasks/main.yml
@@ -32,19 +32,22 @@
 
 #     yum -y --installroot=$CHROOT install nagios-plugins-all-ohpc nrpe-ohpc
   - name: Install packages Nagios plugins for computing node images on master
-    yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-    with_items:
-      - nagios-plugins-all-ohpc
-      - nrpe-ohpc
+    yum:
+      state: latest
+      installroot: "{{ compute_chroot_loc }}"
+      name:
+        - nagios-plugins-all-ohpc
+        - nrpe-ohpc
     when:
       - inventory_hostname in groups[nt_sms]
       - enable_warewulf == true
 
   - name: Install packages Nagios plugins on a computing node
-    yum: name={{ item }} state=latest
-    with_items:
-      - nagios-plugins-all-ohpc
-      - nrpe-ohpc
+    yum:
+      state: latest
+      name:
+        - nagios-plugins-all-ohpc
+        - nrpe-ohpc
     when:
       - inventory_hostname in groups[nt_cnodes]
       - enable_warewulf == false

--- a/roles/net-ib/tasks/main.yml
+++ b/roles/net-ib/tasks/main.yml
@@ -27,9 +27,10 @@
 - block:
 #yum -y groupinstall "InfiniBand Support"
   - name: Install InfiniBand support on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - "@InfiniBand Support"
+    yum:
+      state: latest
+      name:
+        - "@InfiniBand Support"
     when:
       - inventory_hostname in groups[nt_sms]
 
@@ -60,24 +61,25 @@
 
 #yum install required packages for installing MLNX_OFED_LINUX on master
     - name: Install  on master
-      yum: name={{ item }} state=latest
-      with_items:
-        - pciutils
-        - lsof
-        - gtk2
-        - atk
-        - gcc-gfortran
-        - tk
-        - python-devel
-        - pciutils
-        - make
-        - kernel-devel
-        - redhat-rpm-config
-        - rpm-build
-        - gcc
-        - libxml2-python
-        - tcsh
-        - tcl
+      yum:
+        state: latest
+        name:
+          - pciutils
+          - lsof
+          - gtk2
+          - atk
+          - gcc-gfortran
+          - tk
+          - python-devel
+          - pciutils
+          - make
+          - kernel-devel
+          - redhat-rpm-config
+          - rpm-build
+          - gcc
+          - libxml2-python
+          - tcsh
+          - tcl
       when:
         - inventory_hostname in groups[nt_sms]
 
@@ -119,9 +121,10 @@
 
 #     yum -y install opensm
   - name: Install opensm on master
-    yum: name={{ item }} state=latest
-    with_items:
-      - opensm
+    yum:
+      state: latest
+      name:
+        - opensm
 
   - name: Enable virtualization in OpenSM
     lineinfile:
@@ -188,17 +191,20 @@
 - block:
   #yum -y --installroot=$CHROOT groupinstall "InfiniBand Support"
   - name: Install InfiniBand support to computing node images on master
-    yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-    with_items:
-      - "@InfiniBand Support"
+    yum:
+      state: latest
+      installroot: "{{ compute_chroot_loc }}"
+      name:
+        - "@InfiniBand Support"
     when:
       - inventory_hostname in groups[nt_sms]
       - enable_warewulf == true
 
   - name: Install InfiniBand support on computing nodes
-    yum: name={{ item }} state=latest
-    with_items:
-      - "@InfiniBand Support"
+    yum:
+      state: latest
+      name:
+        - "@InfiniBand Support"
     when:
       - inventory_hostname in groups[nt_cnodes]
       - enable_warewulf == false
@@ -260,14 +266,15 @@
 
 #yum install pciutils lsof gtk2 atk gcc-gfortran tk
     - name: Install required packages for installing MLNX_OFED_LINUX on computing node
-      yum: name={{ item }} state=latest
-      with_items:
-        - pciutils
-        - lsof
-        - gtk2
-        - atk
-        - gcc-gfortran
-        - tk
+      yum:
+        state: latest
+        name:
+          - pciutils
+          - lsof
+          - gtk2
+          - atk
+          - gcc-gfortran
+          - tk
       when:
         - inventory_hostname in groups[nt_cnodes]
         - enable_warewulf == false

--- a/roles/net-infinipath/tasks/main.yml
+++ b/roles/net-infinipath/tasks/main.yml
@@ -22,27 +22,31 @@
 
 #yum -y install infinipath-psm
 - name: Install infinipath-psm on master
-  yum: name={{ item }} state=latest
-  with_items:
-    - infinipath-psm
+  yum:
+    state: latest
+    name:
+      - infinipath-psm
   when:
     - inventory_hostname in groups[nt_sms]
     - enable_intel_packages == true
 
 #yum -y --installroot=$CHROOT install infinipath-psm
 - name: Install infinipath-psm to computing node images on master
-  yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-  with_items:
-    - infinipath-psm
+  yum:
+    state: latest
+    installroot: "{{ compute_chroot_loc }}"
+    name:
+      - infinipath-psm
   when:
     - inventory_hostname in groups[nt_sms]
     - enable_warewulf == true
     - enable_intel_packages == true
 
 - name: Install infinipath-psm on computing nodes
-  yum: name={{ item }} state=latest
-  with_items:
-    - infinipath-psm
+  yum:
+    state: latest
+    name:
+      - infinipath-psm
   when:
     - inventory_hostname in groups[nt_cnodes]
     - enable_warewulf == false

--- a/roles/ohpc-base/tasks/main.yml
+++ b/roles/ohpc-base/tasks/main.yml
@@ -25,9 +25,10 @@
 # ------------------------------------------------------------
 #yum -y groupinstall ohpc-base
 - name: Install ohpc-base
-  yum: name={{ item }} state=latest
-  with_items:
-    - ohpc-base
+  yum:
+    state: latest
+    name:
+      - ohpc-base
   when:
     ( inventory_hostname in groups[nt_sms] ) or
     ( inventory_hostname in groups[nt_devnodes] ) or
@@ -35,17 +36,20 @@
 
 #yum -y --installroot=$CHROOT groupinstall ohpc-base-compute
 - name: Install ohpc-base-compute for computing node images on master
-  yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-  with_items:
-    - ohpc-base-compute
+  yum:
+    state: latest
+    installroot: "{{ compute_chroot_loc }}"
+    name:
+      - ohpc-base-compute
   when:
     - inventory_hostname in groups[nt_sms]
     - enable_warewulf == true
 
 - name: Install ohpc-base-compute on computing nodes
-  yum: name={{ item }} state=latest
-  with_items:
-    - ohpc-base-compute
+  yum:
+    state: latest
+    name:
+      - ohpc-base-compute
   when:
     - inventory_hostname in groups[nt_cnodes]
     - enable_warewulf == false

--- a/roles/perf-tools-gnu/tasks/main.yml
+++ b/roles/perf-tools-gnu/tasks/main.yml
@@ -25,17 +25,20 @@
 # ---------------------------------------
 #yum -y groupinstall ohpc-perf-tools-gnu
 - name: Install Performance Tools on master and a development node
-  yum: name={{ item }} state=latest
-  with_items:
-    - "ohpc-gnu{{ gnu_version }}-perf-tools"
+  yum:
+    state: latest
+    name:
+      - "ohpc-gnu{{ gnu_version }}-perf-tools"
   when: 
     ( inventory_hostname in groups[ nt_devnodes ] ) or
     ( ( inventory_hostname in groups[nt_cnodes] ) and ( enable_warewulf == false ) )
 
 - name: Install Performance Tools for a computing image on master
-  yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-  with_items:
-    - "ohpc-gnu{{ gnu_version }}-perf-tools"
+  yum:
+    state: latest
+    installroot: "{{ compute_chroot_loc }}"
+    name:
+      - "ohpc-gnu{{ gnu_version }}-perf-tools"
   when: 
     - inventory_hostname in groups[nt_sms]
     - enable_warewulf == true

--- a/roles/slurm-client/tasks/main.yml
+++ b/roles/slurm-client/tasks/main.yml
@@ -22,17 +22,20 @@
 
 #yum -y --installroot=$CHROOT groupinstall ohpc-slurm-client
 - name: Install ohpc-slurm-client for computing node images on master
-  yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-  with_items:
-    - ohpc-slurm-client
+  yum:
+    state: latest
+    installroot: "{{ compute_chroot_loc }}"
+    name:
+      - ohpc-slurm-client
   when:
     - inventory_hostname in groups[nt_sms]
     - enable_warewulf == true
 
 - name: Install ohpc-slurm-client on computing nodes
-  yum: name={{ item }} state=latest
-  with_items:
-    - ohpc-slurm-client
+  yum:
+    state: latest
+    name:
+      - ohpc-slurm-client
   when:
     - inventory_hostname in groups[nt_cnodes]
     - enable_warewulf == false

--- a/roles/slurm-server/tasks/main.yml
+++ b/roles/slurm-server/tasks/main.yml
@@ -25,8 +25,9 @@
 # -------------------------------------------------------------
 #yum -y groupinstall ohpc-slurm-server
 - name: Install ohpc-slurm-server on master
-  yum: name={{ item }} state=latest
-  with_items:
-    - ohpc-slurm-server
+  yum:
+    state: latest
+    name:
+      - ohpc-slurm-server
   when:
     - inventory_hostname in groups[nt_sms]

--- a/roles/third-party-libs-gnu/tasks/main.yml
+++ b/roles/third-party-libs-gnu/tasks/main.yml
@@ -29,23 +29,26 @@
 #yum -y groupinstall ohpc-gnu8-runtimes
 - block:
   - name: Install packages 3rd Party Libraries and Tools on master and a development node
-    yum: name={{ item }} state=latest
-    with_items:
-      - "ohpc-gnu{{ gnu_version }}-serial-libs"
-      - "ohpc-gnu{{ gnu_version }}-io-libs"
-      - "ohpc-gnu{{ gnu_version }}-python-libs"
-      - "ohpc-gnu{{ gnu_version }}-runtimes"
+    yum:
+      state: latest
+      name:
+        - "ohpc-gnu{{ gnu_version }}-serial-libs"
+        - "ohpc-gnu{{ gnu_version }}-io-libs"
+        - "ohpc-gnu{{ gnu_version }}-python-libs"
+        - "ohpc-gnu{{ gnu_version }}-runtimes"
     when: 
       ( inventory_hostname in groups[nt_devnodes] ) or
       ( ( inventory_hostname in groups[nt_cnodes] ) and ( enable_warewulf == false ) )
 
   - name: Install packages 3rd Party Libraries and Tools for a computing image on master
-    yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-    with_items:
-      - "ohpc-gnu{{ gnu_version }}-serial-libs"
-      - "ohpc-gnu{{ gnu_version }}-io-libs"
-      - "ohpc-gnu{{ gnu_version }}-python-libs"
-      - "ohpc-gnu{{ gnu_version }}-runtimes"
+    yum:
+      state: latest
+      installroot: "{{ compute_chroot_loc }}"
+      name:
+        - "ohpc-gnu{{ gnu_version }}-serial-libs"
+        - "ohpc-gnu{{ gnu_version }}-io-libs"
+        - "ohpc-gnu{{ gnu_version }}-python-libs"
+        - "ohpc-gnu{{ gnu_version }}-runtimes"
     when: 
       - inventory_hostname in groups[nt_sms] 
       - enable_warewulf == true

--- a/roles/third-party-libs-intel/tasks/main.yml
+++ b/roles/third-party-libs-intel/tasks/main.yml
@@ -28,23 +28,26 @@
 #     yum -y groupinstall ohpc-python-libs-intel
 #     yum -y groupinstall ohpc-runtimes-intel
   - name: Install Development libraries for use with Intel Parallel Studio on master and a development node
-    yum: name={{ item }} state=latest
-    with_items:
-      - ohpc-serial-libs-intel
-      - ohpc-io-libs-intel
-      - ohpc-python-libs-intel
-      - ohpc-runtimes-intel
+    yum:
+      state: latest
+      name:
+        - ohpc-serial-libs-intel
+        - ohpc-io-libs-intel
+        - ohpc-python-libs-intel
+        - ohpc-runtimes-intel
     when:
       ( inventory_hostname in groups[nt_devnodes] ) or
       ( ( inventory_hostname in groups[nt_cnodes] ) and ( enable_warewulf == false ) )  
 
   - name: Install Development libraries for use with Intel Parallel Studio for a computing image on master
-    yum: name={{ item }} installroot="{{ compute_chroot_loc }}" state=latest
-    with_items:
-      - ohpc-serial-libs-intel
-      - ohpc-io-libs-intel
-      - ohpc-python-libs-intel
-      - ohpc-runtimes-intel
+    yum:
+      state: latest
+      installroot: "{{ compute_chroot_loc }}"
+      name:
+        - ohpc-serial-libs-intel
+        - ohpc-io-libs-intel
+        - ohpc-python-libs-intel
+        - ohpc-runtimes-intel
     when:
       - inventory_hostname in groups[nt_sms] 
       - enable_warewulf == true 

--- a/roles/warewulf-init/tasks/main.yml
+++ b/roles/warewulf-init/tasks/main.yml
@@ -22,9 +22,10 @@
 
 #yum -y groupinstall ohpc-warewulf
 - name: Install ohpc-warewulf on master
-  yum: name={{ item }} state=latest
-  with_items:
-    - ohpc-warewulf
+  yum: 
+    state: latest
+    name:
+      - ohpc-warewulf
   when:
     - inventory_hostname in groups[nt_sms]
     - enable_warewulf == true


### PR DESCRIPTION
Current implementation causes ansible to issue a deprecation warning that it will stop working at ansible 2.11. Also docs mention `When used with a loop: each package will be processed individually, it is much more efficient to pass the list directly to the name option.` This PR fixes that by turning name in all yum calls into an array
