### PR TITLE
Add root flag by default in run script

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,5 +4,5 @@ if [ -f execution.log ]; then
     rm -f execution.log
 fi
 
-ansible-playbook -i inventory/hosts site.yml -vv
+ansible-playbook -i inventory/hosts site.yml -u root -vv
 


### PR DESCRIPTION
To follow the README's instructions and to accomodate for the #12 PR, this patch is required.