### PR TITLE
Force lmod sourcing defaults

### DIFF
--- a/roles/lmod/tasks/main.yml
+++ b/roles/lmod/tasks/main.yml
@@ -45,3 +45,9 @@
   when:
     - inventory_hostname in groups[nt_sms]
     - enable_warewulf == true
+
+- name: Source the lmod-defaults
+  shell: "module load ohpc"
+  when: 
+    ( inventory_hostname in groups[ nt_devnodes ] ) or
+    ( ( inventory_hostname in groups[nt_cnodes] ) and ( enable_warewulf == false ) )


### PR DESCRIPTION
Force lmod to use the defaults from the package we just installed.
This behaviour was by default last week, now it's not.

Although I will investigate why, it doesn't hurt to make it explicit.